### PR TITLE
Add option to use popup menus for non-editable combos (Gtk like)

### DIFF
--- a/Kvantum/doc/Theme-Config
+++ b/Kvantum/doc/Theme-Config
@@ -205,6 +205,11 @@ combo_as_lineedit                true/false           Draw an editable combo box
                                                       boxes consist of combo, line-edit and
                                                       drop down elements.
 
+combo_menu                        true/false          Should the popup of non-editable combos
+                                                      be styled as per popup menus? (i.e. like
+                                                      Gtk). By default, they are shown below
+                                                      the combo as per editable combos.
+
 left_tabs                         true/false          Align tabs to the left edge?
                                                       Tabs are centered by default.
 

--- a/Kvantum/style/Kvantum.cpp
+++ b/Kvantum/style/Kvantum.cpp
@@ -9452,6 +9452,7 @@ int Style::styleHint(StyleHint hint,
     case SH_Menu_MouseTracking : return true;
 
     case SH_ComboBox_PopupFrameStyle: return QFrame::StyledPanel | QFrame::Plain;
+    case SH_ComboBox_Popup : return tspec_.combo_menu;
 
     case SH_MenuBar_MouseTracking :
       return tspec_.menubar_mouse_tracking;

--- a/Kvantum/style/themeconfig/ThemeConfig.cpp
+++ b/Kvantum/style/themeconfig/ThemeConfig.cpp
@@ -526,6 +526,9 @@ theme_spec ThemeConfig::getThemeSpec()
   v = getValue("General","scrollbar_in_view");
   r.scrollbar_in_view = v.toBool();
 
+  v = getValue("General","combo_menu");
+  r.combo_menu = v.toBool();
+
   v = getValue("General","layout_spacing");
   if (v.isValid()) // 2 by default
     r.layout_spacing = qMin(qMax(v.toInt(),2), 16);

--- a/Kvantum/style/themeconfig/specs.h
+++ b/Kvantum/style/themeconfig/specs.h
@@ -126,6 +126,8 @@ typedef struct {
   bool button_contents_shift;
   /* draw scrollbars within view */
   bool scrollbar_in_view;
+  /* use popup menu for non-editable combo popup */
+  bool combo_menu;
 
   int layout_spacing;
 
@@ -369,6 +371,7 @@ static inline void default_theme_spec(theme_spec &tspec) {
   tspec.groupbox_top_label = false;
   tspec.button_contents_shift = true;
   tspec.scrollbar_in_view = false;
+  tspec.combo_menu = false;
   tspec.layout_spacing = 2;
   tspec.small_icon_size = 16;
   tspec.large_icon_size = 32;


### PR DESCRIPTION
Another simple change. This makes the popup menu of non-editable combos use the menu style - and is more Gtk-like.