### PR TITLE
Make Header view more consistent with Arc.

### DIFF
--- a/Kvantum/themes/kvthemes/KvArc/KvArc.kvconfig
+++ b/Kvantum/themes/kvthemes/KvArc/KvArc.kvconfig
@@ -237,11 +237,15 @@ indicator.element=tree
 inherits=PanelButtonCommand
 interior.element=header
 frame.element=header
-text.bold=true
+text.bold=false
 text.normal.color=#0000008c
 text.focus.color=#5796e8
 text.toggle.color=black
 frame.expansion=0
+frame.top=0
+frame.bottom=0
+frame.left=2
+frame.right=0
 
 [SizeGrip]
 indicator.element=resize-grip


### PR DESCRIPTION
Kvantum seems to need to the frame.left=2 for the divider to show. Looks like these are on the left? Should probably be on the right - then the header text coloud align with the column item texts, currently it is offset