### PR TITLE
Arch: add commit hash, fix makedepends

### DIFF
--- a/Kvantum/Arch/Qt4/cmake/PKGBUILD
+++ b/Kvantum/Arch/Qt4/cmake/PKGBUILD
@@ -11,7 +11,7 @@ url="https://github.com/tsujan/Kvantum"
 license=('GPL')
 groups=('qt')
 depends=('qt4>=4.8.7' 'libx11>=1.6.4' 'libxext>=1.3.3')
-makedepends=()
+makedepends=('cmake' 'unzip')
 checkdepends=()
 optdepends=()
 conflicts=()
@@ -24,6 +24,10 @@ source=("https://github.com/tsujan/Kvantum/archive/master.zip")
 noextract=()
 md5sums=('SKIP')
 validpgpkeys=()
+
+pkgver() {
+	echo ${pkgver}+g$(unzip -q -z "${srcdir}/master.zip" | cut -c1-10)
+}
 
 build() {
 	cd "${srcdir}/${gitname}-master/${gitname}"

--- a/Kvantum/Arch/Qt4/qmake/PKGBUILD
+++ b/Kvantum/Arch/Qt4/qmake/PKGBUILD
@@ -11,7 +11,7 @@ url="https://github.com/tsujan/Kvantum"
 license=('GPL')
 groups=('qt')
 depends=('qt4>=4.8.7' 'libx11>=1.6.4' 'libxext>=1.3.3')
-makedepends=()
+makedepends=('unzip')
 checkdepends=()
 optdepends=()
 conflicts=()
@@ -24,6 +24,10 @@ source=("https://github.com/tsujan/Kvantum/archive/master.zip")
 noextract=()
 md5sums=('SKIP')
 validpgpkeys=()
+
+pkgver() {
+	echo ${pkgver}+g$(unzip -q -z "${srcdir}/master.zip" | cut -c1-10)
+}
 
 build() {
 	cd "${srcdir}/${gitname}-master/${gitname}"

--- a/Kvantum/Arch/Qt5/cmake/PKGBUILD
+++ b/Kvantum/Arch/Qt5/cmake/PKGBUILD
@@ -11,7 +11,7 @@ url="https://github.com/tsujan/Kvantum"
 license=('GPL')
 groups=('qt')
 depends=('qt5-base>=5.7.0' 'qt5-svg>=5.7.0' 'qt5-x11extras>=5.7.0' 'libx11>=1.6.4' 'libxext>=1.3.3')
-makedepends=('qt5-tools>=5.7.0')
+makedepends=('cmake' 'qt5-tools>=5.7.0' 'unzip')
 checkdepends=()
 optdepends=()
 conflicts=()
@@ -24,6 +24,10 @@ source=("https://github.com/tsujan/Kvantum/archive/master.zip")
 noextract=()
 md5sums=('SKIP')
 validpgpkeys=()
+
+pkgver() {
+	echo ${pkgver}+g$(unzip -q -z "${srcdir}/master.zip" | cut -c1-10)
+}
 
 build() {
 	cd "${srcdir}/${gitname}-master/${gitname}"

--- a/Kvantum/Arch/Qt5/qmake/PKGBUILD
+++ b/Kvantum/Arch/Qt5/qmake/PKGBUILD
@@ -11,7 +11,7 @@ url="https://github.com/tsujan/Kvantum"
 license=('GPL')
 groups=('qt')
 depends=('qt5-base>=5.7.0' 'qt5-svg>=5.7.0' 'qt5-x11extras>=5.7.0' 'libx11>=1.6.4' 'libxext>=1.3.3')
-makedepends=('qt5-tools>=5.7.0')
+makedepends=('qt5-tools>=5.7.0' 'unzip')
 checkdepends=()
 optdepends=()
 conflicts=()
@@ -24,6 +24,10 @@ source=("https://github.com/tsujan/Kvantum/archive/master.zip")
 noextract=()
 md5sums=('SKIP')
 validpgpkeys=()
+
+pkgver() {
+	echo ${pkgver}+g$(unzip -q -z "${srcdir}/master.zip" | cut -c1-10)
+}
 
 build() {
 	cd "${srcdir}/${gitname}-master/${gitname}"


### PR DESCRIPTION
Add missing cmake depends. Ensure that version number includes the
commit hash to identify the exact master revision.