### PR TITLE
Arc theme's menubar background

### DIFF
--- a/Kvantum/themes/kvthemes/KvArc/KvArc.kvconfig
+++ b/Kvantum/themes/kvthemes/KvArc/KvArc.kvconfig
@@ -360,8 +360,8 @@ frame.expansion=0
 
 [MenuBar]
 inherits=PanelButtonCommand
-frame.element=none
-interior.element=none
+frame.element=menubar
+interior.element=menubar
 frame.bottom=0
 frame.expansion=0
 

--- a/Kvantum/themes/kvthemes/KvArcDark/KvArcDark.kvconfig
+++ b/Kvantum/themes/kvthemes/KvArcDark/KvArcDark.kvconfig
@@ -360,8 +360,8 @@ frame.expansion=0
 
 [MenuBar]
 inherits=PanelButtonCommand
-frame.element=none
-interior.element=none
+frame.element=menubar
+interior.element=menubar
 frame.bottom=0
 frame.expansion=0
 


### PR DESCRIPTION
Set menubar background, so that even if there is no toolbar it is the correct colour. Needed as we drag via menubar, so it should appear to be
part of the titlebar.