### PR TITLE
More ambiance mods

### DIFF
--- a/Kvantum/style/Kvantum.cpp
+++ b/Kvantum/style/Kvantum.cpp
@@ -1874,7 +1874,7 @@ void Style::polish(QPalette &palette)
   if (col1.isValid())
     palette.setColor(QPalette::Inactive,QPalette::Base,col1);
   else
-    palette.setColor(QPalette::Inactive,QPalette::WindowText,col);
+    palette.setColor(QPalette::Inactive,QPalette::Base,col);
   col = getFromRGBA(cspec_.altBaseColor);
   if (col.isValid())
     palette.setColor(QPalette::AlternateBase,col);

--- a/Kvantum/style/Kvantum.cpp
+++ b/Kvantum/style/Kvantum.cpp
@@ -1870,6 +1870,11 @@ void Style::polish(QPalette &palette)
   col = getFromRGBA(cspec_.baseColor);
   if (col.isValid())
     palette.setColor(QPalette::Base,col);
+  col1 = getFromRGBA(cspec_.inactiveBaseColor);
+  if (col1.isValid())
+    palette.setColor(QPalette::Inactive,QPalette::Base,col1);
+  else
+    palette.setColor(QPalette::Inactive,QPalette::WindowText,col);
   col = getFromRGBA(cspec_.altBaseColor);
   if (col.isValid())
     palette.setColor(QPalette::AlternateBase,col);

--- a/Kvantum/style/themeconfig/ThemeConfig.cpp
+++ b/Kvantum/style/themeconfig/ThemeConfig.cpp
@@ -828,6 +828,9 @@ color_spec ThemeConfig::getColorSpec() const
   v = getValue("GeneralColors","inactive.highlight.color");
   r.inactiveHighlightColor = v.toString();
 
+  v = getValue("GeneralColors","inactive.base.color");
+  r.inactiveBaseColor = v.toString();
+
   v = getValue("GeneralColors","tooltip.base.color");
   r.tooltipBasetColor = v.toString();
 

--- a/Kvantum/style/themeconfig/specs.h
+++ b/Kvantum/style/themeconfig/specs.h
@@ -192,6 +192,7 @@ typedef struct {
 typedef struct {
   QString windowColor;
   QString baseColor;
+  QString inactiveBaseColor;
   QString altBaseColor;
   QString buttonColor;
   QString lightColor;

--- a/Kvantum/themes/kvthemes/KvAmbiance/KvAmbiance.kvconfig
+++ b/Kvantum/themes/kvthemes/KvAmbiance/KvAmbiance.kvconfig
@@ -46,7 +46,7 @@ button_contents_shift=false
 combo_menu=true
 hide_combo_checkboxes=true
 combo_focus_rect=true
-groupbox_top_label=false
+groupbox_top_label=true
 joined_inactive_tabs=true
 layout_margin=9
 respect_DE=true
@@ -466,17 +466,13 @@ text.shadow=false
 
 [GroupBox]
 inherits=GenericFrame
-frame=true
-frame.element=group
+frame=false
+text.shadow=0
 text.margin=0
-frame.top=4
-frame.bottom=4
-frame.left=4
-frame.right=4
-text.normal.color=#000000be
-text.press.color=#4C4C4C
+text.normal.color=#4C4C4C
 text.focus.color=#4C4C4C
 text.bold=true
+frame.expansion=0
 
 [TabBarFrame]
 inherits=PanelButtonCommand

--- a/Kvantum/themes/kvthemes/KvAmbiance/KvAmbiance.kvconfig
+++ b/Kvantum/themes/kvthemes/KvAmbiance/KvAmbiance.kvconfig
@@ -58,6 +58,7 @@ tree_branch_line=true
 [GeneralColors]
 window.color=#f2f1f0
 base.color=white
+inactive.base.color=#F2F1F0
 alt.base.color=#F0F0F0
 button.color=#e9e9e9
 light.color=white


### PR DESCRIPTION
Some more mods for Ambiance:

1. Frameless groupboxes
2. Itemviews have darker base colour (actually window colour) in inactive windows.

I'd also like to make the following mods, but I'm unsure how:

1. Line-edits should also be darker and flat for inactive windows
2. Radios and checkboxes in menus should always follow text colour. i.e. They should be a darker white (as per text) when not selected, becoming white when selected
2. Tri-angular arrows
3. Selected menubar item should be a frame, not orange highlight
4. Scrollbar should not be so rounded
5. Progressbars should be thinner, and have the text on top
6. Remove the inner white border around views
7. Square frame for views