### PR TITLE
2 Missing dependencies on Ubuntu systems

### DIFF
--- a/Kvantum/INSTALL
+++ b/Kvantum/INSTALL
@@ -18,6 +18,8 @@ First install X11 and Qt development packages. In Debian-based systems, they are
  * qtbase5-dev, libqt5svg5-dev and libqt5x11extras5-dev (for Qt5)
  * libkf5windowsystem-dev (required with Qt >= 5.11)
  * qttools5-dev-tools (for localization if you need it)
+ * libqt5svg5-dev
+ * libqt5x11extras5-dev
 
 In Arch-based systems, the packages are:
 


### PR DESCRIPTION
Qt5 SVG and Qt5 X11 extras development packages.
Tested on KDE neon and Kubuntu. Compilation wouldn't finish until both were installed.