### PR TITLE
Changed tab alignment logic

### DIFF
--- a/Kvantum/doc/Theme-Config
+++ b/Kvantum/doc/Theme-Config
@@ -320,14 +320,11 @@ square_combo_button               true/false          Should the combo arrow but
                                                       that case, the whole editable combo box
                                                       will be drawn as a line-edit.
 
-left_tabs                         true/false          Align tabs to the left edge?
+left_tabs                         true/false          Align normal tabs to the left edge.
                                                       Tabs are centered by default.
 
-center_doc_tabs                   true/false          Always center tabs if the tab widget is
-                                                      in the document mode and even when the
-                                                      key "left_tabs" is true? False by default,
-                                                      which means that tabs are aligned in the
-                                                      document mode as in the usual mode.
+center_doc_tabs                   true/false          Center tabs if the tab widget is
+                                                      in the document mode. False by default.
 
 attach_active_tab                 true/false          Attach the active tab to the tab widget
                                                       or the tab-bar base? It is detached

--- a/Kvantum/style/Kvantum.cpp
+++ b/Kvantum/style/Kvantum.cpp
@@ -13135,19 +13135,22 @@ int Style::styleHint(QStyle::StyleHint hint,
       return tspec_.menubar_mouse_tracking;
 
     case SH_TabBar_Alignment : {
-      if (tspec_.left_tabs)
+      const QTabWidget *tw = qobject_cast<const QTabWidget*>(widget);
+      if (!tw || tw->documentMode()) // floating tabs
       {
         if (tspec_.center_doc_tabs)
-        {
-          const QTabWidget *tw = qobject_cast<const QTabWidget*>(widget);
-          if (!tw || tw->documentMode())
-            return Qt::AlignCenter;
-        }
-        return Qt::AlignLeft;
+            return Qt::AlignCenter;  // floating tabs centered
+          else
+            return Qt::AlignLeft;  // floating tabs left-aligned
       }
-      else
-        return Qt::AlignCenter;
-    }
+      else // normal tabs
+      {
+        if (tspec_.left_tabs)
+          return Qt::AlignLeft;  // normal tabs left-aligned
+        else
+          return Qt::AlignCenter;  // normal tabs centered
+      }
+    }      
 
     case SH_TabBar_ElideMode : return Qt::ElideNone; // don't interfere with CE_TabBarTabLabel
 


### PR DESCRIPTION
There was no case when normal tabs are centered and floating tabs are left-aligned.
I propose this change to make center_doc_tabs independent from left_tabs.