### PR TITLE
Changed tool box layout to tab widget

### DIFF
--- a/Kvantum/kvantummanager/KvantumManager.cpp
+++ b/Kvantum/kvantummanager/KvantumManager.cpp
@@ -277,7 +277,7 @@ KvantumManager::~KvantumManager()
 /*************************/
 void KvantumManager::showWindow()
 { // set the first page as the current page and really show the window
-    ui->toolBox->setCurrentIndex (0);
+    ui->toolBox->setCurrentIndex (1);
     resize (minimumSizeHint().expandedTo (QSize (600, 400)));
     hide();
     setAttribute (Qt::WA_DontShowOnScreen, false);

--- a/Kvantum/kvantummanager/KvantumManager.cpp
+++ b/Kvantum/kvantummanager/KvantumManager.cpp
@@ -64,10 +64,10 @@ KvantumManager::KvantumManager (const QString& lang, QWidget *parent) : QMainWin
     ui->aboutButton->setIcon (symbolicIcon::icon (":/Icons/data/help-about.svg"));
     ui->quit->setIcon (symbolicIcon::icon (":/Icons/data/application-exit.svg"));
 
-    ui->toolBox->setItemIcon (0, symbolicIcon::icon (":/Icons/data/system-software-install.svg"));
-    ui->toolBox->setItemIcon (1, symbolicIcon::icon (":/Icons/data/preferences-desktop-theme.svg"));
-    ui->toolBox->setItemIcon (2, symbolicIcon::icon (":/Icons/data/preferences-system.svg"));
-    ui->toolBox->setItemIcon (3, symbolicIcon::icon (":/Icons/data/applications-system.svg"));
+    ui->toolBox->setTabIcon (0, symbolicIcon::icon (":/Icons/data/system-software-install.svg"));
+    ui->toolBox->setTabIcon (1, symbolicIcon::icon (":/Icons/data/preferences-desktop-theme.svg"));
+    ui->toolBox->setTabIcon (2, symbolicIcon::icon (":/Icons/data/preferences-system.svg"));
+    ui->toolBox->setTabIcon (3, symbolicIcon::icon (":/Icons/data/applications-system.svg"));
 
     /* The default clear icon doesn't follow the color palette when the theme is changed.
        So, we replace it with our SVG icon. */
@@ -164,7 +164,7 @@ KvantumManager::KvantumManager (const QString& lang, QWidget *parent) : QMainWin
     connect (ui->checkBoxTransient, &QAbstractButton::clicked, this, &KvantumManager::trantsientScrollbarEnbled);
     connect (ui->lineEdit, &QLineEdit::textChanged, this, &KvantumManager::txtChanged);
     connect (ui->appsEdit, &QLineEdit::textChanged, this, &KvantumManager::txtChanged);
-    connect (ui->toolBox, &QToolBox::currentChanged, this, &KvantumManager::tabChanged);
+    connect (ui->toolBox, &QTabWidget::currentChanged, this, &KvantumManager::tabChanged);
     connect (ui->tabWidget, &QTabWidget::currentChanged, this, &KvantumManager::setTabWidgetFocus);
     connect (ui->saveAppButton, &QAbstractButton::clicked, this, &KvantumManager::writeAppLists);
     connect (ui->removeAppButton, &QAbstractButton::clicked, this, &KvantumManager::removeAppList);

--- a/Kvantum/kvantummanager/kvantummanager.ui
+++ b/Kvantum/kvantummanager/kvantummanager.ui
@@ -23,7 +23,7 @@
      <number>10</number>
     </property>
     <item row="0" column="0" colspan="4">
-     <widget class="QToolBox" name="toolBox">
+     <widget class="QTabWidget" name="toolBox">
       <property name="sizePolicy">
        <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
         <horstretch>0</horstretch>
@@ -34,7 +34,7 @@
        <number>2</number>
       </property>
       <widget class="QWidget" name="page">
-       <attribute name="label">
+       <attribute name="title">
         <string>Install/Update Theme</string>
        </attribute>
        <layout class="QGridLayout" name="gridLayout">
@@ -134,7 +134,7 @@ Kvantum can use in addition to its own themes.</string>
        </layout>
       </widget>
       <widget class="QWidget" name="page_2">
-       <attribute name="label">
+       <attribute name="title">
         <string>Change/Delete Theme</string>
        </attribute>
        <layout class="QGridLayout" name="gridLayout_2">
@@ -253,7 +253,7 @@ the theme is already used.</string>
        </layout>
       </widget>
       <widget class="QWidget" name="page_3">
-       <attribute name="label">
+       <attribute name="title">
         <string>Configure Active Theme</string>
        </attribute>
        <layout class="QGridLayout" name="gridLayout_4">
@@ -2039,7 +2039,7 @@ the Ctrl key before pressing the button.</string>
          <height>303</height>
         </rect>
        </property>
-       <attribute name="label">
+       <attribute name="title">
         <string>Application Themes</string>
        </attribute>
        <layout class="QGridLayout" name="gridLayout_6">


### PR DESCRIPTION
- Changed the tool box widget to a tab widget, as in my opinion it is less confusing and easier to work with: 
![grafik](https://user-images.githubusercontent.com/46622675/173548741-e61649e6-8294-45df-8ae4-4265d5072c3c.png)

- Changed the page we see at startup to the _Apply theme_ page, as this is probably what most people want to see when they start the application.

Ideally I would move the _Install_ and _Configure_ pages to buttons on what is now the _Select theme_ page, but this is way more work and will likely break translations.