### PR TITLE
kvprew; fixing layout in combo tab

### DIFF
--- a/Kvantum/kvantumpreview/KvantumPreviewBase.ui
+++ b/Kvantum/kvantumpreview/KvantumPreviewBase.ui
@@ -1088,22 +1088,9 @@ check box</string>
        </property>
       </spacer>
      </item>
-     <item row="1" column="0">
-      <spacer name="horizontalSpacer_8">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>0</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="1" column="1">
+     <item row="1" column="1" rowspan="2">
       <layout class="QGridLayout" name="gridLayout_8">
-       <item row="0" column="0">
+       <item row="0" column="1">
         <widget class="QComboBox" name="comboBox">
          <item>
           <property name="text">
@@ -1139,7 +1126,7 @@ check box</string>
          </item>
         </widget>
        </item>
-       <item row="0" column="1" rowspan="2">
+       <item row="0" column="2">
         <widget class="QComboBox" name="comboBox_7">
          <property name="enabled">
           <bool>false</bool>
@@ -1178,7 +1165,7 @@ check box</string>
          </item>
         </widget>
        </item>
-       <item row="1" column="0" rowspan="2">
+       <item row="1" column="1">
         <widget class="QComboBox" name="comboBox_3">
          <property name="frame">
           <bool>false</bool>
@@ -1248,7 +1235,7 @@ check box</string>
          </item>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="1" column="2">
         <widget class="QComboBox" name="comboBox_8">
          <property name="enabled">
           <bool>false</bool>
@@ -1321,7 +1308,7 @@ check box</string>
          </item>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="2" column="1">
         <widget class="QComboBox" name="comboBox_2">
          <property name="editable">
           <bool>true</bool>
@@ -1361,7 +1348,7 @@ check box</string>
          </item>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="2" column="2">
         <widget class="QComboBox" name="comboBox_5">
          <property name="enabled">
           <bool>false</bool>
@@ -1404,7 +1391,7 @@ check box</string>
          </item>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="3" column="1">
         <widget class="QComboBox" name="comboBox_4">
          <property name="editable">
           <bool>true</bool>
@@ -1483,7 +1470,7 @@ check box</string>
          </item>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="3" column="2">
         <widget class="QComboBox" name="comboBox_6">
          <property name="enabled">
           <bool>false</bool>
@@ -1565,7 +1552,7 @@ check box</string>
          </item>
         </widget>
        </item>
-       <item row="5" column="0">
+       <item row="4" column="1">
         <widget class="QLineEdit" name="lineEdit">
          <property name="text">
           <string>Line-edit</string>
@@ -1575,7 +1562,7 @@ check box</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="4" column="2">
         <widget class="QLineEdit" name="lineEdit_3">
          <property name="enabled">
           <bool>false</bool>
@@ -1588,7 +1575,7 @@ check box</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="5" column="1">
         <widget class="QLineEdit" name="lineEdit_2">
          <property name="text">
           <string>Frameless (no difference)</string>
@@ -1598,7 +1585,7 @@ check box</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="5" column="2">
         <widget class="QLineEdit" name="lineEdit_4">
          <property name="enabled">
           <bool>false</bool>
@@ -1611,17 +1598,24 @@ check box</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="0">
+       <item row="6" column="1">
         <widget class="QSpinBox" name="spinBox"/>
        </item>
-       <item row="7" column="1">
+       <item row="6" column="2">
         <widget class="QSpinBox" name="spinBox_2">
          <property name="enabled">
           <bool>false</bool>
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="7" column="1">
+        <widget class="QDateTimeEdit" name="dateTimeEdit">
+         <property name="buttonSymbols">
+          <enum>QAbstractSpinBox::PlusMinus</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="2">
         <widget class="QDateTimeEdit" name="dateTimeEdit_2">
          <property name="enabled">
           <bool>false</bool>
@@ -1631,16 +1625,9 @@ check box</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="0">
-        <widget class="QDateTimeEdit" name="dateTimeEdit">
-         <property name="buttonSymbols">
-          <enum>QAbstractSpinBox::PlusMinus</enum>
-         </property>
-        </widget>
-       </item>
       </layout>
      </item>
-     <item row="1" column="2">
+     <item row="1" column="2" rowspan="2">
       <spacer name="horizontalSpacer_7">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -1653,7 +1640,7 @@ check box</string>
        </property>
       </spacer>
      </item>
-     <item row="2" column="1">
+     <item row="3" column="1">
       <spacer name="verticalSpacer_9">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
@@ -1662,6 +1649,19 @@ check box</string>
         <size>
          <width>20</width>
          <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="1" column="0" rowspan="2">
+      <spacer name="horizontalSpacer_8">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>20</height>
         </size>
        </property>
       </spacer>


### PR DESCRIPTION
Nothing problematic, but anyway...

before:
![prewcombotab_old](https://github.com/tsujan/Kvantum/assets/2953887/20430bf0-a0cd-45d2-80c0-1b83e7f1e589)

patched:
![prewcombotab_new](https://github.com/tsujan/Kvantum/assets/2953887/73436b7b-8a4a-40f7-929d-36cd897015b6)
