### PR TITLE
docs: update Kvantum installation instructions for openSUSE Tumbleweed

### DIFF
--- a/Kvantum/INSTALL.md
+++ b/Kvantum/INSTALL.md
@@ -104,7 +104,7 @@ Kvantum is now available directly in the official openSUSE Tumbleweed repositori
 
 ```bash
 sudo zypper refresh
-sudo zypper install kvantum-manager kvantum-qt6
+sudo zypper install kvantum-manager kvantum-qt6 kvantum-qt5
 ```
 
 ### Red Hat based distributions

--- a/Kvantum/INSTALL.md
+++ b/Kvantum/INSTALL.md
@@ -99,10 +99,13 @@ If you want to compile Kvantum from its source, install these packages:
 see [Compilation](#compilation) on how to compile and install Kvantum.
 
 #### Tumbleweed
-Thanks to [trmdi](https://github.com/trmdi), you can install Kvantum directly, by executing:
 
-    sudo zypper ar obs://home:trmdi trmdi
-    sudo zypper in -r trmdi kvantum
+Kvantum is now available directly in the official openSUSE Tumbleweed repositories (repo-oss):
+
+```bash
+sudo zypper refresh
+sudo zypper install kvantum-manager kvantum-qt6
+```
 
 ### Red Hat based distributions
 


### PR DESCRIPTION
Kvantum is now available in the official openSUSE Tumbleweed repositories (repo-oss), so there is no need to compile it from source or use trmdi OBS repository (which no longer hosts Kvantum).

Updated the documentation to reflect the simpler installation method